### PR TITLE
Handle variable Pluto frame length in universal receiver capture

### DIFF
--- a/Universal/runPlutoradioUniversalReceiver.m
+++ b/Universal/runPlutoradioUniversalReceiver.m
@@ -50,11 +50,18 @@ end
 currentTime = 0;
 BER = [];
 num_frames = floor(prmUniversalReceiver.StopTime*radio.BasebandSampleRate/radio.SamplesPerFrame);
-rcvdSignal = complex(zeros(prmUniversalReceiver.PlutoFrameLength, num_frames));
+frameLength = radio.SamplesPerFrame;
+rcvdSignal = complex(zeros(frameLength, num_frames));
 
 cnt = 1;
 while currentTime <  prmUniversalReceiver.StopTime && cnt<=num_frames
-    rcvdSignal(:,cnt) = radio();
+    samples = radio();
+    samples = samples(:);
+    if numel(samples) ~= frameLength
+        error('runPlutoradioUniversalReceiver:UnexpectedFrameLength', ...
+            'Radio returned %d samples, expected %d.', numel(samples), frameLength);
+    end
+    rcvdSignal(:,cnt) = samples;
     [~, ~, ~, BER] = rx(rcvdSignal(:,cnt));
     currentTime=currentTime+(radio.SamplesPerFrame / radio.BasebandSampleRate);
     cnt = cnt+1;


### PR DESCRIPTION
## Summary
- derive the Pluto capture frame length from the configured radio object rather than the expected parameter value
- validate that captured frames match the expected length and reshape hardware output into a column vector before processing

## Testing
- not run (hardware dependent)

------
https://chatgpt.com/codex/tasks/task_e_68e6279d0fec83309db3666b26a637dc