### PR TITLE
Ensure Pluto transmitter always releases hardware

### DIFF
--- a/Universal/runPlutoradioUniversalTransmitter.m
+++ b/Universal/runPlutoradioUniversalTransmitter.m
@@ -8,7 +8,13 @@ function runPlutoradioUniversalTransmitter(prmUniversalTransmitter)
 % Copyright 2017-2023 The MathWorks, Inc.
 
 persistent hTx radio
-if isempty(hTx)
+if coder.target('MATLAB')
+    cleanupObj = onCleanup(@()cleanupTransmitter()); %#ok<NASGU>
+else
+    cleanupObj = []; %#ok<NASGU>
+end
+
+if isempty(hTx) || ~isvalid(hTx)
     cfg = helperModulationConfig(prmUniversalTransmitter.ModulationOrder);
     hTx = UniversalTransmitter(...
         'ModulationOrder',              cfg.ModulationOrder, ...
@@ -46,7 +52,20 @@ if currentTime ~= 0
     disp('Transmission has ended')
 end
 
-release(hTx);
-release(radio);
+if ~coder.target('MATLAB')
+    cleanupTransmitter();
+end
+
+    function cleanupTransmitter()
+        if ~isempty(hTx) && isvalid(hTx)
+            release(hTx);
+        end
+        hTx = [];
+
+        if ~isempty(radio) && isvalid(radio)
+            release(radio);
+        end
+        radio = [];
+    end
 
 end


### PR DESCRIPTION
## Summary
- add cleanup handling so the Universal Pluto transmitter releases hardware resources even when interrupted
- reset persistent transmitter objects after cleanup to allow subsequent runs to reinitialize cleanly

## Testing
- not run (requires MATLAB/Pluto hardware)


------
https://chatgpt.com/codex/tasks/task_e_68e630c538c48330b3ff73526496898c